### PR TITLE
Redo error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clparse"
 version = "0.1.0"
-description = "A command line tool for parsing CHANGELOGd files that use the Keep A Changelog format."
+description = "A command line tool for parsing CHANGELOG.md files that use the Keep A Changelog format."
 authors = ["Marc Addeo <hi@marc.cx>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ semver = { version = "0.9.0", features = ["serde"] }
 pulldown-cmark = "0.5.3"
 chrono = { version = "0.4.7", features = ["serde"] }
 derive_builder = "0.7.2"
-failure = "0.1.5"
 serde = "1.0.100"
 serde_derive = "1.0.100"
 serde_json = "1.0.40"
@@ -26,3 +25,5 @@ clap = { version = "2.33.0", features = ["yaml", "suggestions", "color"] }
 serde_yaml = "0.8.9"
 fstrings = "0.1.4"
 indexmap = "1.2.0"
+anyhow = "1.0.3"
+err-derive = "0.1.6"

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,7 @@
+use anyhow::Result;
+use err_derive::Error;
 use chrono::NaiveDate;
 use derive_builder::Builder;
-use failure::Fail;
 use fstrings::*;
 use indexmap::indexmap;
 use semver::Version;
@@ -18,9 +19,9 @@ pub enum Change {
     Security(String),
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum ChangeError {
-    #[fail(display = "invalid change type specified: {}", _0)]
+    #[error(display = "invalid change type specified: {}", _0)]
     InvalidChangeType(String),
 }
 
@@ -49,7 +50,7 @@ pub struct Changelog {
 }
 
 impl Change {
-    pub fn new(change_type: &str, description: String) -> Result<Self, ChangeError> {
+    pub fn new(change_type: &str, description: String) -> Result<Self> {
         use self::Change::*;
 
         match change_type.to_lowercase().as_str() {
@@ -59,7 +60,7 @@ impl Change {
             "removed" => Ok(Removed(description)),
             "fixed" => Ok(Fixed(description)),
             "security" => Ok(Security(description)),
-            _ => Err(ChangeError::InvalidChangeType(change_type.to_string())),
+            _ => Err(ChangeError::InvalidChangeType(change_type.to_string()).into()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,17 +216,3 @@ impl ChangelogParser {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    extern crate serde_json;
-
-    #[test]
-    fn it_works() {
-        let cl = ChangelogParser::parse(PathBuf::from("test_changelog.md")).unwrap();
-
-        println!("{}", serde_json::to_string_pretty(&cl).unwrap());
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
+use anyhow::Result;
 use clap::{
     app_from_crate, crate_authors, crate_description, crate_name, crate_version, AppSettings, Arg,
 };
 use clparse::ChangelogParser;
-use failure::Error;
 use std::io::{self, Read};
 
-pub fn main() -> Result<(), Error> {
+pub fn main() -> Result<()> {
     let matches = app_from_crate!()
         .setting(AppSettings::DisableHelpSubcommand)
         .global_setting(AppSettings::ColoredHelp)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,12 @@ use std::io::{self, Read};
 pub fn main() -> Result<()> {
     let matches = app_from_crate!()
         .setting(AppSettings::DisableHelpSubcommand)
+        .setting(AppSettings::ArgRequiredElseHelp)
         .global_setting(AppSettings::ColoredHelp)
         .arg(
             Arg::with_name("format")
                 .help("Sets the output format of the parsed CHANGELOG")
                 .takes_value(true)
-                .default_value("markdown")
                 .possible_values(&["json", "yaml", "yml", "markdown", "md"])
                 .short("f")
                 .long("format"),
@@ -37,7 +37,7 @@ pub fn main() -> Result<()> {
         ChangelogParser::parse(file.into())?
     };
 
-    match matches.value_of("format").unwrap() {
+    match matches.value_of("format").unwrap_or("markdown") {
         "json" => {
             println!("{}", serde_json::to_string_pretty(&changelog)?);
         }


### PR DESCRIPTION
* Switch over to `anyhow::Error` and `err-derive` instead of `failure` as it's more ergonomic.
* Update the binary to show the help screen if no args are passed instead of errors
* Fix typo in description
* Remove tests that did nothing