### PR TITLE
Add setters and mut getters for structs

### DIFF
--- a/.cl/add-setters-and-mut-getters.yml
+++ b/.cl/add-setters-and-mut-getters.yml
@@ -1,0 +1,2 @@
+---
+- added: Add some setters and mut getters for the Release and Changelog structs

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -41,6 +41,42 @@ pub struct Release {
 }
 
 impl Release {
+    pub fn version_mut(&mut self) -> &mut Option<Version> {
+        &mut self.version
+    }
+
+    pub fn set_version(&mut self, version: Version) -> &mut Self {
+        self.version = Some(version);
+        self
+    }
+
+    pub fn link_mut(&mut self) -> &mut Option<String> {
+        &mut self.link
+    }
+
+    pub fn set_link(&mut self, link: String) -> &mut Self {
+        self.link = Some(link);
+        self
+    }
+
+    pub fn date_mut(&mut self) -> &mut Option<NaiveDate> {
+        &mut self.date
+    }
+
+    pub fn set_date(&mut self, date: NaiveDate) -> &mut Self {
+        self.date = Some(date);
+        self
+    }
+
+    pub fn changes_mut(&mut self) -> &mut Vec<Change> {
+        &mut self.changes
+    }
+
+    pub fn set_changes(&mut self, changes: Vec<Change>) -> &mut Self {
+        self.changes = changes;
+        self
+    }
+
     pub fn yank(&mut self, yanked: bool) {
         if !self.yanked && yanked {
             self.link = None;
@@ -68,6 +104,11 @@ impl Changelog {
             .map(|r| r.changes.clone())
             .flatten()
             .collect()
+    }
+
+    pub fn unreleased_mut(&mut self) -> Option<&mut Release> {
+        self.releases.iter_mut()
+            .find(|r| r.version == None)
     }
 
     pub fn release_mut(&mut self, release: Version) -> Option<&mut Release> {


### PR DESCRIPTION
This adds some helper functions to the Changelog and Release structs for setters and mut getters to allow additional functionality in `cl`