### PR TITLE
Prepare CHANGELOG for 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.0] - 2020-07-28
 ### Added
 - Add some setters and mut getters for the Release and Changelog structs
 
@@ -60,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial implementation of `clparse` library and binary
 
-[Unreleased]: https://github.com/marcaddeo/clparse/compare/0.7.0...HEAD
+[Unreleased]: https://github.com/marcaddeo/clparse/compare/0.8.0...HEAD
+[0.8.0]: https://github.com/marcaddeo/clparse/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/marcaddeo/clparse/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/marcaddeo/clparse/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/marcaddeo/clparse/compare/0.4.0...0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clparse"
-version = "0.7.0"
+version = "0.8.0"
 description = "A command line tool for parsing CHANGELOG.md files that use the Keep A Changelog format."
 keywords = ["changelog", "parser", "keepachangelog"]
 categories = ["command-line-utilities", "development-tools", "text-processing"]

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ $ brew install marcaddeo/clsuite/clparse
 
 ### Debian
 ```
-$ curl -LO https://github.com/marcaddeo/clparse/releases/download/0.7.0/clparse_0.7.0_amd64.deb
-$ sudo dpkg -i clparse_0.7.0_amd64.deb
+$ curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.0/clparse_0.8.0_amd64.deb
+$ sudo dpkg -i clparse_0.8.0_amd64.deb
 ```
 
 ### Linux
 ```
-$ curl -LO https://github.com/marcaddeo/clparse/releases/download/0.7.0/clparse-0.7.0-x86_64-unknown-linux-musl.tar.gz
-$ tar czvf clparse-0.7.0-x86_64-unknown-linux-musl.tar.gz
+$ curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.0/clparse-0.8.0-x86_64-unknown-linux-musl.tar.gz
+$ tar czvf clparse-0.8.0-x86_64-unknown-linux-musl.tar.gz
 $ sudo mv clparse /usr/local/bin/clparse
 ```
 
@@ -30,7 +30,7 @@ $ cargo install clparse
 
 ## Usage
 ```
-clparse 0.7.0
+clparse 0.8.0
 Marc Addeo <hi@marc.cx>
 A command line tool for parsing CHANGELOG.md files that use the Keep A Changelog format.
 


### PR DESCRIPTION


## [0.8.0] - 2020-07-28
### Added
- Add some setters and mut getters for the Release and Changelog structs



[Unreleased]: https://github.com/marcaddeo/clparse/compare/0.8.0...HEAD
[0.8.0]: https://github.com/marcaddeo/clparse/compare/0.7.0...release/0.8.0
[0.7.0]: https://github.com/marcaddeo/clparse/compare/0.6.0...0.7.0
[0.6.0]: https://github.com/marcaddeo/clparse/compare/0.5.0...0.6.0
[0.5.0]: https://github.com/marcaddeo/clparse/compare/0.4.0...0.5.0
[0.4.0]: https://github.com/marcaddeo/clparse/compare/0.3.0...0.4.0
[0.3.0]: https://github.com/marcaddeo/clparse/compare/0.2.0...0.3.0
[0.2.0]: https://github.com/marcaddeo/clparse/compare/0.1.0...0.2.0
[0.1.0]: https://github.com/marcadde/clparse/releases/tag/0.1.0
