### PR TITLE
Bump err-derive from 0.1.6 to 0.2.4.

### DIFF
--- a/.cl/fix-err-derive.yml
+++ b/.cl/fix-err-derive.yml
@@ -1,0 +1,2 @@
+---
+- changed: Bump err-derive from 0.1.6 to 0.2.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,6 @@ clap = { version = "2.33.0", features = ["yaml", "suggestions", "color"] }
 serde_yaml = "0.8.9"
 indexmap = "1.2.0"
 anyhow = "1.0.3"
-err-derive = "0.1.6"
+err-derive = "0.2.4"
 derive-getters = "0.1.0"
 textwrap = "0.11.0"


### PR DESCRIPTION
#19 identified that there was an issue when running `cargo install clparse`. This fixes #19 by updating the `err-derive` crate to the latest version.