### PR TITLE
Add support for arbitrary separators, non-semver versions, disabling wrapping, and customizing wrapping character count

### DIFF
--- a/.cl/22/arbitary-separators-and-non-semver-support/changes.yml
+++ b/.cl/22/arbitary-separators-and-non-semver-support/changes.yml
@@ -1,0 +1,2 @@
+---
+ - added: "Add support for using an arbitrary separator character between the version and date of a release heading using the `--separator` flag"

--- a/.cl/22/arbitary-separators-and-non-semver-support/changes.yml
+++ b/.cl/22/arbitary-separators-and-non-semver-support/changes.yml
@@ -1,2 +1,3 @@
 ---
  - added: "Add support for using an arbitrary separator character between the version and date of a release heading using the `--separator` flag"
+ - added: Add support for parsing non-semver versions

--- a/.cl/22/arbitary-separators-and-non-semver-support/changes.yml
+++ b/.cl/22/arbitary-separators-and-non-semver-support/changes.yml
@@ -1,3 +1,5 @@
 ---
  - added: "Add support for using an arbitrary separator character between the version and date of a release heading using the `--separator` flag"
  - added: Add support for parsing non-semver versions
+ - added: "Add support for disabling wrapping of changelog release entries using the `--no-wrap` flag"
+ - added: "Add support for wrapping at a custom character count using the `--wrap-at` option"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ name = "clparse"
 path = "src/main.rs"
 
 [dependencies]
-semver = { version = "0.10.0", features = ["serde"] }
 pulldown-cmark = "0.5.3"
 chrono = { version = "0.4.7", features = ["serde"] }
 derive_builder = "0.7.2"
@@ -39,3 +38,4 @@ anyhow = "1.0.3"
 err-derive = "0.2.4"
 derive-getters = "0.1.0"
 textwrap = "0.11.0"
+versions = { version = "5.0.1", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "A command line tool for parsing CHANGELOG.md files that use the K
 keywords = ["changelog", "parser", "keepachangelog"]
 categories = ["command-line-utilities", "development-tools", "text-processing"]
 homepage = "https://github.com/marcaddeo/clparse"
+readme = "README.md"
 repository = "https://github.com/marcaddeo/clparse"
 documentation = "https://github.com/marcaddeo/clparse#clparse"
 authors = ["Marc Addeo <hi@marc.cx>"]

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ Marc Addeo <hi@marc.cx>
 A command line tool for parsing CHANGELOG.md files that use the Keep A Changelog format.
 
 USAGE:
-    clparse [OPTIONS] <FILE>
+    clparse [FLAGS] [OPTIONS] <FILE>
 
 FLAGS:
     -h, --help       Prints help information
+    -n, --no-wrap    Disable wrapping of change entries of a release. By default, change entries are wrapped at 80
+                     characters.
     -V, --version    Prints version information
 
 OPTIONS:
@@ -46,6 +48,7 @@ OPTIONS:
                                    json, yaml, yml, markdown, md]
     -s, --separator <separator>    Sets the separator character used between version and date in a release heading
                                    [default: -]
+    -w, --wrap-at <wrap-at>        Specify how many characters to wrap change entries at [default: 80]
 
 ARGS:
     <FILE>    The CHANGELOG file to parse. This should be either a Markdown, JSON, or Yaml representation of a

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -f, --format <format>    Sets the output format of the parsed CHANGELOG [default: markdown] [possible values: json,
-                             yaml, yml, markdown, md]
+    -f, --format <format>          Sets the output format of the parsed CHANGELOG [default: markdown] [possible values:
+                                   json, yaml, yml, markdown, md]
+    -s, --separator <separator>    Sets the separator character used between version and date in a release heading
+                                   [default: -]
 
 ARGS:
     <FILE>    The CHANGELOG file to parse. This should be either a Markdown, JSON, or Yaml representation of a

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
-use err_derive::Error;
 use chrono::NaiveDate;
 use derive_builder::Builder;
 use derive_getters::Getters;
+use err_derive::Error;
 use indexmap::indexmap;
 use semver::Version;
 use serde_derive::{Deserialize, Serialize};
@@ -98,7 +98,8 @@ pub struct Changelog {
 
 impl Changelog {
     pub fn unreleased_changes(&self) -> Vec<Change> {
-        self.releases.clone()
+        self.releases
+            .clone()
             .into_iter()
             .filter(|r| r.version.is_none())
             .map(|r| r.changes.clone())
@@ -107,12 +108,12 @@ impl Changelog {
     }
 
     pub fn unreleased_mut(&mut self) -> Option<&mut Release> {
-        self.releases.iter_mut()
-            .find(|r| r.version == None)
+        self.releases.iter_mut().find(|r| r.version == None)
     }
 
     pub fn release_mut(&mut self, release: Version) -> Option<&mut Release> {
-        self.releases.iter_mut()
+        self.releases
+            .iter_mut()
             .find(|r| r.version == Some(release.clone()))
     }
 }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -38,6 +38,15 @@ pub struct Release {
     changes: Vec<Change>,
     #[builder(default = "false")]
     yanked: bool,
+    #[serde(skip)]
+    #[builder(default = "self.default_separator()")]
+    separator: String,
+}
+
+impl ReleaseBuilder {
+    fn default_separator(&self) -> String {
+        "-".into()
+    }
 }
 
 impl Release {
@@ -165,9 +174,9 @@ impl fmt::Display for Release {
         // Release Version.
         if let (Some(version), Some(date)) = (self.version.as_ref(), self.date) {
             if self.yanked {
-                fmt.write_str(&format!("{} - {} [YANKED]\n", version, date))?;
+                fmt.write_str(&format!("{} {} {} [YANKED]\n", version, self.separator, date))?;
             } else {
-                fmt.write_str(&format!("[{}] - {}\n", version, date))?;
+                fmt.write_str(&format!("[{}] {} {}\n", version, self.separator, date))?;
             }
         } else {
             fmt.write_str("[Unreleased]\n")?;

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -4,7 +4,8 @@ use derive_builder::Builder;
 use derive_getters::Getters;
 use err_derive::Error;
 use indexmap::indexmap;
-use semver::Version;
+use versions::Version;
+use serde::ser::Serializer;
 use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use textwrap::wrap;
@@ -26,9 +27,20 @@ pub enum ChangeError {
     InvalidChangeType(String),
 }
 
+fn version_serialize<S>(x: &Option<Version>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match x {
+        Some(ref version) => s.serialize_str(&version.to_string()),
+        None => s.serialize_none(),
+    }
+}
+
 #[derive(Debug, Clone, Builder, Getters, Serialize, Deserialize, PartialEq)]
 pub struct Release {
     #[builder(setter(strip_option), default)]
+    #[serde(serialize_with = "version_serialize")]
     version: Option<Version>,
     #[builder(setter(strip_option, into), default)]
     link: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,10 +168,6 @@ impl ChangelogParser {
                     ChangelogSection::ReleaseHeader => {
                         let text = text.trim();
 
-                        if text == "YANKED" {
-                            release.yanked(true);
-                        }
-
                         let mut date_format = format!("{} %Y-%m-%d", self.separator);
                         let split: Vec<&str> = text.split(&format!(" {} ", self.separator)).collect();
 
@@ -184,8 +180,14 @@ impl ChangelogParser {
                                 continue;
                             }
 
+                            if string == "YANKED" {
+                                release.yanked(true);
+                                continue;
+                            }
+
                             if let Ok(date) = NaiveDate::parse_from_str(&string, &date_format) {
                                 release.date(date);
+                                continue;
                             }
 
                             if let Some(version) = Version::new(&string) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,17 +156,12 @@ impl ChangelogParser {
                             link_accumulator.push_str(&text);
                         }
                     }
-                    ChangelogSection::ReleaseHeader => {
-                        if text != "Unreleased".into() {
-                            accumulator.push_str(&text);
-                        }
-                    }
                     ChangelogSection::ChangesetHeader => {
                         self.parse_release_header(&mut release, &mut accumulator);
 
                         section = ChangelogSection::Changeset(text.to_string())
                     }
-                    ChangelogSection::Changeset(_) => accumulator.push_str(&text),
+                    ChangelogSection::Changeset(_) | ChangelogSection::ReleaseHeader => accumulator.push_str(&text),
                     _ => (),
                 },
                 _ => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use changelog::{Change, Changelog, ChangelogBuilder, Release, ReleaseBuilder};
 use chrono::NaiveDate;
 use err_derive::Error;
 use pulldown_cmark::{Event, LinkType, Parser, Tag};
-use semver::Version;
+use versions::Version;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::PathBuf;
@@ -177,11 +177,15 @@ impl ChangelogParser {
                         }
 
                         for string in split {
+                            if string == "Unreleased" {
+                                continue;
+                            }
+
                             if let Ok(date) = NaiveDate::parse_from_str(&string, &date_format) {
                                 release.date(date);
                             }
 
-                            if let Ok(version) = Version::parse(&string) {
+                            if let Some(version) = Version::new(&string) {
                                 release.version(version);
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,14 @@ pub enum ChangelogParserError {
 
 pub struct ChangelogParser {
     separator: String,
+    wrap: Option<usize>,
 }
 
 impl ChangelogParser {
-    pub fn new(separator: String) -> Self {
+    pub fn new(separator: String, wrap: Option<usize>) -> Self {
         Self {
-            separator
+            separator,
+            wrap,
         }
     }
 
@@ -92,6 +94,7 @@ impl ChangelogParser {
                         ChangelogSection::Changeset(_) | ChangelogSection::ReleaseHeader => {
                             release.changes(changeset.clone());
                             release.separator(self.separator.clone());
+                            release.wrap(self.wrap);
                             releases.push(
                                 release
                                     .build()
@@ -202,6 +205,7 @@ impl ChangelogParser {
 
         release.changes(changeset.clone());
         release.separator(self.separator.clone());
+        release.wrap(self.wrap);
         releases.push(
             release
                 .build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use err_derive::Error;
 use changelog::{Change, Changelog, ChangelogBuilder, Release, ReleaseBuilder};
 use chrono::NaiveDate;
+use err_derive::Error;
 use pulldown_cmark::{Event, LinkType, Parser, Tag};
 use semver::Version;
 use std::fs::File;
@@ -82,7 +82,11 @@ impl ChangelogParser {
                         }
                         ChangelogSection::Changeset(_) | ChangelogSection::ReleaseHeader => {
                             release.changes(changeset.clone());
-                            releases.push(release.build().map_err(ChangelogParserError::ErrorBuildingRelease)?);
+                            releases.push(
+                                release
+                                    .build()
+                                    .map_err(ChangelogParserError::ErrorBuildingRelease)?,
+                            );
 
                             changeset = Vec::new();
                             release = ReleaseBuilder::default();
@@ -183,7 +187,11 @@ impl ChangelogParser {
         }
 
         release.changes(changeset.clone());
-        releases.push(release.build().map_err(ChangelogParserError::ErrorBuildingRelease)?);
+        releases.push(
+            release
+                .build()
+                .map_err(ChangelogParserError::ErrorBuildingRelease)?,
+        );
 
         if !description_links.is_empty() {
             description = format!("{}{}\n", description, description_links);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,20 @@ pub fn main() -> Result<()> {
                 .long("separator"),
         )
         .arg(
+            Arg::with_name("no-wrap")
+                .help("Disable wrapping of change entries of a release. By default, change entries are wrapped at 80 characters.")
+                .takes_value(false)
+                .short("n")
+                .long("no-wrap"),
+        )
+        .arg(
+            Arg::with_name("wrap-at")
+                .help("Specify how many characters to wrap change entries at [default: 80]")
+                .takes_value(true)
+                .short("w")
+                .long("wrap-at"),
+        )
+        .arg(
             Arg::with_name("file")
                 .help("The CHANGELOG file to parse. This should be either a Markdown, JSON, or Yaml representation of a changelog. Use '-' to read from stdin.")
                 .value_name("FILE")
@@ -36,7 +50,15 @@ pub fn main() -> Result<()> {
 
     let file = matches.value_of("file").unwrap();
     let separator = matches.value_of("separator").unwrap_or("-");
-    let parser = ChangelogParser::new(separator.into());
+
+    let no_wrap = matches.is_present("no-wrap");
+    let wrap_at = matches.value_of("wrap-at").unwrap_or("80");
+    let wrap = match (no_wrap, wrap_at) {
+        (true, _) => None,
+        (false, wrap_at) => Some(wrap_at.parse::<usize>()?),
+    };
+
+    let parser = ChangelogParser::new(separator.into(), wrap);
     let changelog = if file == "-" {
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,13 @@ pub fn main() -> Result<()> {
                 .long("format"),
         )
         .arg(
+            Arg::with_name("separator")
+                .help("Sets the separator character used between version and date in a release heading [default: -]")
+                .takes_value(true)
+                .short("s")
+                .long("separator"),
+        )
+        .arg(
             Arg::with_name("file")
                 .help("The CHANGELOG file to parse. This should be either a Markdown, JSON, or Yaml representation of a changelog. Use '-' to read from stdin.")
                 .value_name("FILE")
@@ -28,13 +35,15 @@ pub fn main() -> Result<()> {
         .get_matches();
 
     let file = matches.value_of("file").unwrap();
+    let separator = matches.value_of("separator").unwrap_or("-");
+    let parser = ChangelogParser::new(separator.into());
     let changelog = if file == "-" {
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer)?;
 
-        ChangelogParser::parse_buffer(buffer)?
+        parser.parse_buffer(buffer)?
     } else {
-        ChangelogParser::parse(file.into())?
+        parser.parse(file.into())?
     };
 
     let output = match matches.value_of("format").unwrap_or("markdown") {


### PR DESCRIPTION
- Add support for using an arbitrary separator character between the version
  and date of a release heading using the `--separator` flag
- Add support for parsing non-semver versions
- Add support for disabling wrapping of changelog release entries using the
  `--no-wrap` flag
- Add support for wrapping at a custom character count using the `--wrap-at`
  option