### PR TITLE
Prepare for 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.9.0] - 2023-10-24
 ### Added
 - Add support for using an arbitrary separator character between the version
   and date of a release heading using the `--separator` flag
@@ -77,7 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial implementation of `clparse` library and binary
 
-[Unreleased]: https://github.com/marcaddeo/clparse/compare/0.8.1...HEAD
+[Unreleased]: https://github.com/marcaddeo/clparse/compare/0.9.0...HEAD
+[0.9.0]: https://github.com/marcaddeo/clparse/compare/0.8.1...0.9.0
 [0.8.1]: https://github.com/marcaddeo/clparse/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/marcaddeo/clparse/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/marcaddeo/clparse/compare/0.6.0...0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clparse"
-version = "0.8.1"
+version = "0.9.0"
 description = "A command line tool for parsing CHANGELOG.md files that use the Keep A Changelog format."
 keywords = ["changelog", "parser", "keepachangelog"]
 categories = ["command-line-utilities", "development-tools", "text-processing"]

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ $ brew install marcaddeo/clsuite/clparse
 
 ### Debian
 ```
-$ curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.1/clparse_0.8.1_amd64.deb
-$ sudo dpkg -i clparse_0.8.1_amd64.deb
+$ curl -LO https://github.com/marcaddeo/clparse/releases/download/0.9.0/clparse_0.9.0_amd64.deb
+$ sudo dpkg -i clparse_0.9.0_amd64.deb
 ```
 
 ### Linux
 ```
-$ curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.1/clparse-0.8.1-x86_64-unknown-linux-musl.tar.gz
-$ tar czvf clparse-0.8.1-x86_64-unknown-linux-musl.tar.gz
+$ curl -LO https://github.com/marcaddeo/clparse/releases/download/0.9.0/clparse-0.9.0-x86_64-unknown-linux-musl.tar.gz
+$ tar czvf clparse-0.9.0-x86_64-unknown-linux-musl.tar.gz
 $ sudo mv clparse /usr/local/bin/clparse
 ```
 
@@ -30,7 +30,7 @@ $ cargo install clparse
 
 ## Usage
 ```
-clparse 0.8.1
+clparse 0.9.0
 Marc Addeo <hi@marc.cx>
 A command line tool for parsing CHANGELOG.md files that use the Keep A Changelog format.
 


### PR DESCRIPTION
## [0.9.0] - 2023-10-24
### Added
- Add support for using an arbitrary separator character between the version
  and date of a release heading using the `--separator` flag
- Add support for parsing non-semver versions
- Add support for disabling wrapping of changelog release entries using the
  `--no-wrap` flag
- Add support for wrapping at a custom character count using the `--wrap-at`
  option

[0.9.0]: https://github.com/marcaddeo/clparse/compare/0.8.1...release/0.9.0